### PR TITLE
Fix NXQL correlated wildcard queries on MongoDB

### DIFF
--- a/modules/core/nuxeo-core-storage-mongodb/src/main/java/org/nuxeo/ecm/core/storage/mongodb/MongoDBRepositoryQueryBuilder.java
+++ b/modules/core/nuxeo-core-storage-mongodb/src/main/java/org/nuxeo/ecm/core/storage/mongodb/MongoDBRepositoryQueryBuilder.java
@@ -93,7 +93,7 @@ public class MongoDBRepositoryQueryBuilder extends MongoDBAbstractSearchBuilder 
 
     private static final Logger log = LogManager.getLogger(MongoDBRepositoryQueryBuilder.class);
 
-    protected static final Pattern SLASH_WILDCARD_SLASH = Pattern.compile("/(\\\\*(\\\\d+(/)?)?)?");
+    protected static final Pattern SLASH_WILDCARD_SLASH = Pattern.compile("/\\*\\d+(/)?");
 
     protected final SchemaManager schemaManager;
 

--- a/modules/core/nuxeo-core-storage-mongodb/src/main/java/org/nuxeo/ecm/core/storage/mongodb/query/MongoDBAbstractSearchBuilder.java
+++ b/modules/core/nuxeo-core-storage-mongodb/src/main/java/org/nuxeo/ecm/core/storage/mongodb/query/MongoDBAbstractSearchBuilder.java
@@ -233,6 +233,10 @@ public abstract class MongoDBAbstractSearchBuilder {
             // TODO use inverse operators?
             case MongoDBOperators.LT, MongoDBOperators.GT, MongoDBOperators.LTE, MongoDBOperators.GTE ->
                 new Document(MongoDBOperators.NOT, ob);
+            // NOT (field $elemMatch E) -> field $not ($elemMatch E)
+            // (negated existence over a correlated wildcard, e.g. NXQL
+            // NOT (list/*1/a = x AND list/*1/b = y); also matches documents without the field)
+            case MongoDBOperators.ELEM_MATCH -> new Document(MongoDBOperators.NOT, ob);
             default -> throw new QueryParseException("Unknown operator for NOT: " + key);
         };
     }


### PR DESCRIPTION
## What is broken

Correlated wildcard NXQL queries silently return no results on MongoDB. Any query of this shape is affected:

```sql
SELECT * FROM AIP
WHERE prep:pluginReports/*1/plugin-name = 'pdfValidationPlugin'
  AND prep:pluginReports/*1/status = 'WARNING'
```

The query parses fine and returns 200, but matches nothing, even when a document contains a list entry that satisfies both predicates. Negating such a query (`NOT (...)`) fails harder, with a 500.

These queries are used by preservation actions to target packages by plugin outcome, file format and other nested AIP structure fields.

## Root cause

Two independent defects in the NXQL to MongoDB translation.

**1. Broken wildcard-prefix regex**

A past upstream sync merge replaced `SLASH_WILDCARD_SLASH` in `MongoDBRepositoryQueryBuilder` with a double-escaped pattern:

```java
Pattern.compile("/(\\\\*(\\\\d+(/)?)?)?")   // matches literal backslashes, never a wildcard
```

This variant exists in no upstream version (checked branches `2025` and `master`). Because the pattern never matches `/*1`, the `$elemMatch` clause is built with a stray `.*` in its field and full unstripped paths inside it. Captured with the MongoDB profiler:

```js
// emitted (matches nothing)
{ "prep:pluginReports.*": { $elemMatch: { $and: [
    { "prep:pluginReports.plugin-name": "pdfValidationPlugin" },
    { "prep:pluginReports.status": "WARNING" } ] } } }

// correct
{ "prep:pluginReports": { $elemMatch: {
    "plugin-name": "pdfValidationPlugin",
    "status": "WARNING" } } }
```

**2. `pushDownNot` cannot negate `$elemMatch`**

Once the regex is fixed, `NOT (list/*1/a = x AND list/*1/b = y)` throws `Unknown operator for NOT: $elemMatch`, because `pushDownNot` has no case for it.

## The fix

- Restore the regex byte-identical to upstream (`/\\*\\d+(/)?`), which also prevents the same merge conflict from resurfacing on the next sync.
- Add the `$elemMatch` case to `pushDownNot`: `NOT (field $elemMatch E)` becomes `field $not ($elemMatch E)`.

## Verification

Run against a local repository with a document whose plugin-report list contains `[fileMetadataPlugin: SUCCESS, pdfValidationPlugin: WARNING]`:

| Query | Before | After |
|---|---|---|
| correlated pair matching one entry | 0 | 1 |
| correlated pair spanning two entries (must not match) | 0 | 0 |
| single wildcard predicate (regression) | ok | ok |
| `NOT (correlated pair)` | 500 | correct counts |
| uncorrelated wildcards, `IN`, `ILIKE`, `NOT (wildcard)` (regression) | ok | ok |

Profiler confirms the emitted `$elemMatch` filter now has the correct field base and relative inner paths.
